### PR TITLE
Make icy.sh run from any directory

### DIFF
--- a/icy.sh
+++ b/icy.sh
@@ -1,1 +1,1 @@
-java -jar updater.jar
+java -jar `dirname $0`/updater.jar


### PR DESCRIPTION
Currently icy.sh assumes that update.jar is in the current directory. However, if you run icy.sh from a path that does not contain icy, it will fail to start. This small change fixes this issue.